### PR TITLE
Introduce gRPC-based Add Numbers Service.

### DIFF
--- a/gRPC/CMakeLists.txt
+++ b/gRPC/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+project(grpcAddNumbers)
+
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+
+include_directories(${Protobuf_INCLUDE_DIRS})
+
+add_executable(server server.cpp add_numbers.pb.cc add_numbers.grpc.pb.cc)
+target_link_libraries(server gRPC::grpc++ protobuf::libprotobuf)
+
+add_executable(client client.cpp add_numbers.pb.cc add_numbers.grpc.pb.cc)
+target_link_libraries(client gRPC::grpc++ protobuf::libprotobuf)

--- a/gRPC/client.cpp
+++ b/gRPC/client.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include "add_numbers.grpc.pb.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using addnumbers::Adder;
+using addnumbers::AddRequest;
+using addnumbers::AddReply;
+
+class AdderClient {
+public:
+    AdderClient(std::shared_ptr<Channel> channel)
+        : stub_(Adder::NewStub(channel)) {}
+
+    int AddNumbers(int a, int b) {
+        AddRequest request;
+        request.set_a(a);
+        request.set_b(b);
+
+        AddReply reply;
+        ClientContext context;
+
+        Status status = stub_->Add(&context, request, &reply);
+
+        if (status.ok()) {
+            return reply.result();
+        } else {
+            std::cerr << "RPC failed: " << status.error_message() << std::endl;
+            return 0;
+        }
+    }
+
+private:
+    std::unique_ptr<Adder::Stub> stub_;
+};
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " <a> <b>" << std::endl;
+        return 1;
+    }
+
+    int a = std::stoi(argv[1]);
+    int b = std::stoi(argv[2]);
+
+    AdderClient client(grpc::CreateChannel("localhost:50051", grpc::InsecureChannelCredentials()));
+    int result = client.AddNumbers(a, b);
+    std::cout << a << " + " << b << " = " << result << std::endl;
+
+    return 0;
+}

--- a/gRPC/main.cpp
+++ b/gRPC/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}

--- a/gRPC/proto/add_numbers.proto
+++ b/gRPC/proto/add_numbers.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package addnumbers;
+
+service Adder {
+    rpc Add (AddRequest) returns (AddReply) {}
+}
+
+message AddRequest {
+    int32 a = 1;
+    int32 b = 2;
+}
+
+message AddReply {
+    int32 result = 1;
+}

--- a/gRPC/server.cpp
+++ b/gRPC/server.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include "add_numbers.grpc.pb.h"
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using addnumbers::Adder;
+using addnumbers::AddRequest;
+using addnumbers::AddReply;
+
+class AdderServiceImpl final : public Adder::Service {
+    Status Add(ServerContext* context, const AddRequest* request,
+               AddReply* reply) override {
+        int result = request->a() + request->b();
+        reply->set_result(result);
+        std::cout << "Received: " << request->a() << " + " << request->b() << " = " << result << std::endl;
+        return Status::OK;
+    }
+};
+
+void RunServer() {
+    std::string server_address("0.0.0.0:50051");
+    AdderServiceImpl service;
+
+    ServerBuilder builder;
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service);
+    std::unique_ptr<Server> server(builder.BuildAndStart());
+    std::cout << "Server listening on " << server_address << std::endl;
+    server->Wait();
+}
+
+int main() {
+    RunServer();
+    return 0;
+}


### PR DESCRIPTION
- Implement `server.cpp` to provide gRPC service for addition.
- Add `client.cpp` to consume the gRPC service for input number operations.
- Define Protobuf schema in `add_numbers.proto` and generate gRPC code.
- Include `CMakeLists.txt` for building server and client executables.